### PR TITLE
Allow custom confirm and cancel text (+ pickerOptions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ Various configuration options.
 | `confirmText` | `string` | The confirm button text. |
 | `cancelText`  | `string` | The cancel button text.  |
 
-Something is missing? [Submit an issue!](https://github.com/s77rt/react-native-date-picker/issues/new)
-
 ## Methods
 
 Imperative handle methods.
@@ -121,6 +119,10 @@ Imperative handle methods.
 | Method       | Type         | Description       |
 | ------------ | ------------ | ----------------- |
 | `showPicker` | `() => void` | Shows the picker. |
+
+## Feeedback
+
+Every code review, bug report and feature request is appreaciated! Please feel free to [share your feedback](https://github.com/s77rt/react-native-date-picker/issues/new).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Inherits [View Props](https://reactnative.dev/docs/view#props).
 | `min`      | `Date`                          | The earliest selectable date.                       |
 | `max`      | `Date`                          | The latest selectable date.                         |
 | `inline`   | `boolean`                       | Whether the date picker should be displayed inline. |
+| `options`  | [`Options`](#options)           | [Options](#options).                                |
+
+### Options
+
+| Option        | Type     | Description              |
+| ------------- | -------- | ------------------------ |
+| `confirmText` | `string` | The confirm button text. |
+| `cancelText`  | `string` | The cancel button text.  |
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Imperative handle methods.
 | ------------ | ------------ | ----------------- |
 | `showPicker` | `() => void` | Shows the picker. |
 
-## Feeedback
+## Feedback
 
 Every code review, bug report and feature request is appreaciated! Please feel free to [share your feedback](https://github.com/s77rt/react-native-date-picker/issues/new).
 

--- a/README.md
+++ b/README.md
@@ -92,25 +92,31 @@ function Example() {
 
 Inherits [View Props](https://reactnative.dev/docs/view#props).
 
-| Prop       | Type                            | Description                                         |
-| ---------- | ------------------------------- | --------------------------------------------------- |
-| `ref`      | `Ref<DatePickerHandle>`         | Ref for the date picker handle.                     |
-| `type`     | `"date" \| "time"`              | The type of the picker.                             |
-| `value`    | `Date \| null`                  | The selected date.                                  |
-| `onChange` | `(value: Date \| null) => void` | Callback when the user changes the selected date.   |
-| `min`      | `Date`                          | The earliest selectable date.                       |
-| `max`      | `Date`                          | The latest selectable date.                         |
-| `inline`   | `boolean`                       | Whether the date picker should be displayed inline. |
-| `options`  | [`Options`](#options)           | [Options](#options).                                |
+| Prop       | Type                            | Description                                                                                   |
+| ---------- | ------------------------------- | --------------------------------------------------------------------------------------------- |
+| `ref`      | `Ref<DatePickerHandle>`         | Ref for the date picker handle.                                                               |
+| `type`     | `"date" \| "time"`              | The type of the picker.                                                                       |
+| `value`    | `Date \| null`                  | The selected date.                                                                            |
+| `onChange` | `(value: Date \| null) => void` | Callback when the user changes the selected date.                                             |
+| `min`      | `Date`                          | The earliest selectable date.                                                                 |
+| `max`      | `Date`                          | The latest selectable date.                                                                   |
+| `inline`   | `boolean`                       | Whether the date picker should be displayed inline.                                           |
+| `options`  | [`Options`](#options)           | Options. **Note:** Must be memoized ([`useMemo`](https://react.dev/reference/react/useMemo)). |
 
 ### Options
+
+Various configuration options.
 
 | Option        | Type     | Description              |
 | ------------- | -------- | ------------------------ |
 | `confirmText` | `string` | The confirm button text. |
 | `cancelText`  | `string` | The cancel button text.  |
 
+Something is missing? [Submit an issue!](https://github.com/s77rt/react-native-date-picker/issues/new)
+
 ## Methods
+
+Imperative handle methods.
 
 | Method       | Type         | Description       |
 | ------------ | ------------ | ----------------- |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Imperative handle methods.
 
 ## Feedback
 
-Every code review, bug report and feature request is appreaciated! Please feel free to [share your feedback](https://github.com/s77rt/react-native-date-picker/issues/new).
+Every code review, bug report and feature request is appreciated! Please feel free to [share your feedback](https://github.com/s77rt/react-native-date-picker/issues/new).
 
 ## License
 

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePicker.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePicker.kt
@@ -100,4 +100,22 @@ class RTNDatePicker : FrameLayout {
     ) {
         viewModel.updateRange(lowerBound, upperBound)
     }
+
+    public fun setConfirmText(confirmText: String?) {
+        if (confirmText == null) {
+            viewModel.updateConfirmText(reactContext.getString(android.R.string.ok))
+            return
+        }
+
+        viewModel.updateConfirmText(confirmText)
+    }
+
+    public fun setCancelText(cancelText: String?) {
+        if (cancelText == null) {
+            viewModel.updateCancelText(reactContext.getString(android.R.string.cancel))
+            return
+        }
+
+        viewModel.updateCancelText(cancelText)
+    }
 }

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerManager.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerManager.kt
@@ -31,6 +31,7 @@ class RTNDatePickerManager(
         if (type == null) {
             return
         }
+
         view.setType(type)
     }
 
@@ -71,7 +72,6 @@ class RTNDatePickerManager(
         range: ReadableMap?,
     ) {
         if (range == null) {
-            view.setRange(null, null)
             return
         }
 
@@ -79,6 +79,19 @@ class RTNDatePickerManager(
         val upperBound = if (range.hasKey("upperBound")) range.getDouble("upperBound").toLong() else null
 
         view.setRange(lowerBound, upperBound)
+    }
+
+    @ReactProp(name = "options")
+    override fun setOptions(
+        view: RTNDatePicker,
+        options: ReadableMap?,
+    ) {
+        if (options == null) {
+            return
+        }
+
+        view.setConfirmText(options.getString("confirmText"))
+        view.setCancelText(options.getString("cancelText"))
     }
 
     public override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any> =

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerManager.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerManager.kt
@@ -56,7 +56,7 @@ class RTNDatePickerManager(
         view: RTNDatePicker,
         value: Double,
     ) {
-        // Codegen passes null as 0f (0.0)
+        // Codegen passes null double as 0f (0.0)
         // https://github.com/facebook/react-native/blob/996be870713cd72df1f91db99e8f981bbc5406af/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js#L107
         if (value == 0.0) {
             view.setValue(null)

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerView.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerView.kt
@@ -12,12 +12,14 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -124,7 +126,7 @@ fun TimePickerDialog(
             tonalElevation = DatePickerDefaults.TonalElevation,
             color = DatePickerDefaults.colors().containerColor,
         ) {
-            Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 24.dp), verticalArrangement = Arrangement.SpaceBetween) {
+            Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.SpaceBetween) {
                 Text(
                     text = "Select time",
                     modifier = Modifier.padding(bottom = 20.dp),
@@ -138,8 +140,10 @@ fun TimePickerDialog(
                         Modifier.align(Alignment.End),
                 ) {
                     Row {
-                        dismissButton()
-                        confirmButton()
+                        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
+                            dismissButton()
+                            confirmButton()
+                        }
                     }
                 }
             }

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerView.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerView.kt
@@ -42,6 +42,8 @@ fun RTNDatePickerView(
     val isInline by viewModel.isInline.collectAsState()
     val datePickerState by viewModel.datePickerState.collectAsState()
     val timePickerState by viewModel.timePickerState.collectAsState()
+    val confirmText by viewModel.confirmText.collectAsState()
+    val cancelText by viewModel.cancelText.collectAsState()
 
     LaunchedEffect(datePickerState.selectedDateMillis, timePickerState.hour, timePickerState.minute) {
         val date = datePickerState.selectedDateMillis
@@ -67,12 +69,12 @@ fun RTNDatePickerView(
                 onDismissRequest = onCancel,
                 confirmButton = {
                     TextButton(onClick = onConfirm) {
-                        Text("Confirm")
+                        Text(confirmText)
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = onCancel) {
-                        Text("Cancel")
+                        Text(cancelText)
                     }
                 },
             ) {
@@ -87,12 +89,12 @@ fun RTNDatePickerView(
                 onDismissRequest = onCancel,
                 confirmButton = {
                     TextButton(onClick = onConfirm) {
-                        Text("Confirm")
+                        Text(confirmText)
                     }
                 },
                 dismissButton = {
                     TextButton(onClick = onCancel) {
-                        Text("Cancel")
+                        Text(cancelText)
                     }
                 },
             ) {

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerViewModel.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerViewModel.kt
@@ -52,12 +52,16 @@ class RTNDatePickerViewModel : ViewModel() {
                 is24Hour = false,
             ),
         )
+    private val _confirmText = MutableStateFlow("Confirm")
+    private val _cancelText = MutableStateFlow("Cancel")
 
     val type: StateFlow<String> get() = _type
     val isOpen: StateFlow<Boolean> get() = _isOpen
     val isInline: StateFlow<Boolean> get() = _isInline
     val datePickerState: StateFlow<DatePickerState> get() = _datePickerState
     val timePickerState: StateFlow<TimePickerState> get() = _timePickerState
+    val confirmText: StateFlow<String> get() = _confirmText
+    val cancelText: StateFlow<String> get() = _cancelText
 
     fun syncDisplayedMonth() {
         var newDisplayedMonthMillis = _datePickerState.value.selectedDateMillis
@@ -158,5 +162,13 @@ class RTNDatePickerViewModel : ViewModel() {
             }
 
         syncDisplayedMonth()
+    }
+
+    fun updateConfirmText(newConfirmText: String) {
+        _confirmText.value = newConfirmText
+    }
+
+    fun updateCancelText(newCancelText: String) {
+        _cancelText.value = newCancelText
     }
 }

--- a/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerViewModel.kt
+++ b/android/src/main/java/com/s77rt/rtndatepicker/RTNDatePickerViewModel.kt
@@ -52,7 +52,7 @@ class RTNDatePickerViewModel : ViewModel() {
                 is24Hour = false,
             ),
         )
-    private val _confirmText = MutableStateFlow("Confirm")
+    private val _confirmText = MutableStateFlow("OK")
     private val _cancelText = MutableStateFlow("Cancel")
 
     val type: StateFlow<String> get() = _type

--- a/ios/RTNDatePicker.mm
+++ b/ios/RTNDatePicker.mm
@@ -39,30 +39,54 @@ using namespace facebook::react;
     _view = [[RTNDatePickerUIView alloc] initWithFrame:frame];
     _view.delegate = self;
 
-    [_view setTypeWithType:[NSString stringWithUTF8String:defaultViewProps.type
-                                                              .c_str()]];
+    {
+      [_view setTypeWithType:[NSString stringWithUTF8String:defaultViewProps
+                                                                .type.c_str()]];
+    }
 
-    [_view setIsOpenWithIsOpen:defaultViewProps.isOpen];
+    { [_view setIsOpenWithIsOpen:defaultViewProps.isOpen]; }
 
-    [_view setIsInlineWithIsInline:defaultViewProps.isInline];
+    { [_view setIsInlineWithIsInline:defaultViewProps.isInline]; }
 
-    [_view
-        setValueWithDate:[NSDate dateWithTimeIntervalSince1970:defaultViewProps
-                                                                   .value]];
+    {
+      [_view setValueWithDate:[NSDate
+                                  dateWithTimeIntervalSince1970:defaultViewProps
+                                                                    .value]];
+    }
 
-    // Codegen props are zero-initialized (undefined values are zeroed by
-    // default)
-    NSDate *lowerBound =
-        defaultViewProps.range.lowerBound == 0.0
-            ? NSDate.distantPast
-            : [NSDate dateWithTimeIntervalSince1970:defaultViewProps.range
-                                                        .lowerBound];
-    NSDate *upperBound =
-        defaultViewProps.range.upperBound == 0.0
-            ? NSDate.distantFuture
-            : [NSDate dateWithTimeIntervalSince1970:defaultViewProps.range
-                                                        .upperBound];
-    [_view setRangeWithLowerBound:lowerBound upperBound:upperBound];
+    {
+      // Codegen props of type double are zero-initialized (undefined values are
+      // zeroed by default)
+      NSDate *lowerBound =
+          defaultViewProps.range.lowerBound == 0.0
+              ? NSDate.distantPast
+              : [NSDate dateWithTimeIntervalSince1970:defaultViewProps.range
+                                                          .lowerBound];
+      NSDate *upperBound =
+          defaultViewProps.range.upperBound == 0.0
+              ? NSDate.distantFuture
+              : [NSDate dateWithTimeIntervalSince1970:defaultViewProps.range
+                                                          .upperBound];
+      [_view setRangeWithLowerBound:lowerBound upperBound:upperBound];
+    }
+
+    {
+      // Codegen props of type string are zero-initialized (undefined values are
+      // empty by default)
+      NSString *confirmText =
+          defaultViewProps.options.confirmText.empty()
+              ? nil
+              : [NSString stringWithUTF8String:defaultViewProps.options
+                                                   .confirmText.c_str()];
+      [_view setConfirmTextWithConfirmText:confirmText];
+
+      NSString *cancelText =
+          defaultViewProps.options.cancelText.empty()
+              ? nil
+              : [NSString stringWithUTF8String:defaultViewProps.options
+                                                   .cancelText.c_str()];
+      [_view setCancelTextWithCancelText:cancelText];
+    }
 
     self.contentView = _view;
   }
@@ -98,8 +122,8 @@ using namespace facebook::react;
 
   if (oldViewProps.range.lowerBound != newViewProps.range.lowerBound ||
       oldViewProps.range.upperBound != newViewProps.range.upperBound) {
-    // Codegen props are zero-initialized (undefined values are zeroed by
-    // default)
+    // Codegen props of type double are zero-initialized (undefined values are
+    // zeroed by default)
     NSDate *lowerBound =
         newViewProps.range.lowerBound == 0.0
             ? NSDate.distantPast
@@ -111,6 +135,25 @@ using namespace facebook::react;
             : [NSDate
                   dateWithTimeIntervalSince1970:newViewProps.range.upperBound];
     [_view setRangeWithLowerBound:lowerBound upperBound:upperBound];
+  }
+
+  if (oldViewProps.options.confirmText != newViewProps.options.confirmText ||
+      oldViewProps.options.cancelText != newViewProps.options.cancelText) {
+    // Codegen props of type string are zero-initialized (undefined values are
+    // empty by default)
+    NSString *confirmText =
+        newViewProps.options.confirmText.empty()
+            ? nil
+            : [NSString stringWithUTF8String:newViewProps.options.confirmText
+                                                 .c_str()];
+    [_view setConfirmTextWithConfirmText:confirmText];
+
+    NSString *cancelText =
+        newViewProps.options.cancelText.empty()
+            ? nil
+            : [NSString
+                  stringWithUTF8String:newViewProps.options.cancelText.c_str()];
+    [_view setCancelTextWithCancelText:cancelText];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/RTNDatePickerManager.mm
+++ b/ios/RTNDatePickerManager.mm
@@ -15,5 +15,6 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onConfirm, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCancel, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(range, RTNDatePickerRangeStruct)
+RCT_EXPORT_VIEW_PROPERTY(options, RTNDatePickerOptionsStruct)
 
 @end

--- a/ios/RTNDatePickerUIView.swift
+++ b/ios/RTNDatePickerUIView.swift
@@ -60,4 +60,14 @@ import SwiftUI
   @objc public func setRange(lowerBound: Date, upperBound: Date) {
     viewModel.range = lowerBound...upperBound
   }
+
+  @objc public func setConfirmText(confirmText: String?) {
+    let localizedKey = String.LocalizationValue(stringLiteral: confirmText ?? "Done")
+    viewModel.confirmText = String(localized: localizedKey)
+  }
+
+  @objc public func setCancelText(cancelText: String?) {
+    let localizedKey = String.LocalizationValue(stringLiteral: cancelText ?? "Cancel")
+    viewModel.cancelText = String(localized: localizedKey)
+  }
 }

--- a/ios/RTNDatePickerView.swift
+++ b/ios/RTNDatePickerView.swift
@@ -50,12 +50,12 @@ struct RTNDatePickerView: View {
             HStack {
               Button(
                 action: onCancel,
-                label: { Text("Cancel") }
+                label: { Text(viewModel.cancelText) }
               )
               Spacer()
               Button(
                 action: onConfirm,
-                label: { Text("Confirm").bold() }
+                label: { Text(viewModel.confirmText).bold() }
               )
             }
           }

--- a/ios/RTNDatePickerViewModel.swift
+++ b/ios/RTNDatePickerViewModel.swift
@@ -6,7 +6,7 @@ class RTNDatePickerViewModel: ObservableObject {
   @Published var isInline: Bool = false
   @Published var value: Date = Date()
   @Published var range: ClosedRange<Date> = Date.distantPast...Date.distantFuture
-  @Published var confirmText: String = "Confirm"
+  @Published var confirmText: String = "Done"
   @Published var cancelText: String = "Cancel"
 
   init() {}

--- a/ios/RTNDatePickerViewModel.swift
+++ b/ios/RTNDatePickerViewModel.swift
@@ -6,6 +6,8 @@ class RTNDatePickerViewModel: ObservableObject {
   @Published var isInline: Bool = false
   @Published var value: Date = Date()
   @Published var range: ClosedRange<Date> = Date.distantPast...Date.distantFuture
+  @Published var confirmText: String = "Confirm"
+  @Published var cancelText: String = "Cancel"
 
   init() {}
 }

--- a/js/DatePicker/index.native.tsx
+++ b/js/DatePicker/index.native.tsx
@@ -6,9 +6,12 @@ import React, {
 } from "react";
 import { StyleSheet } from "react-native";
 import type { NativeSyntheticEvent } from "react-native";
-import type { DatePickerProps } from "./types";
+import type {
+	DatePickerProps,
+	InternalChangeEvent,
+	InternalRange,
+} from "./types";
 import RTNDatePickerNativeComponent from "../RTNDatePickerNativeComponent";
-import type { ChangeEvent, Range } from "../RTNDatePickerNativeComponent";
 import {
 	defaultDateValue,
 	defaultSize,
@@ -24,12 +27,13 @@ function DatePicker({
 	min: minProp,
 	max: maxProp,
 	inline: isInline = false,
+	options: optionsProp,
 	style: styleProp,
 	...rest
 }: DatePickerProps) {
 	const [isOpen, setIsOpen] = useState(false);
 
-	const range = useMemo<Range>(
+	const range = useMemo<InternalRange>(
 		() => ({
 			lowerBound:
 				minProp === undefined
@@ -68,7 +72,7 @@ function DatePicker({
 	}
 
 	const onChange = useCallback(
-		(event: NativeSyntheticEvent<ChangeEvent>) => {
+		(event: NativeSyntheticEvent<InternalChangeEvent>) => {
 			setValue(event.nativeEvent.value);
 
 			// In inline mode every change is considered a confirmed change
@@ -97,6 +101,8 @@ function DatePicker({
 		setValue(initialValue);
 		setIsOpen(false);
 	}, [initialValue]);
+
+	const options = useMemo(() => optionsProp ?? {}, [optionsProp]);
 
 	const style = useMemo(
 		() =>
@@ -130,6 +136,7 @@ function DatePicker({
 			onConfirm={onConfirm}
 			onCancel={onCancel}
 			range={range}
+			options={options}
 			style={style}
 			{...rest}
 		/>

--- a/js/DatePicker/types.ts
+++ b/js/DatePicker/types.ts
@@ -5,6 +5,20 @@ export type DatePickerHandle = {
 	showPicker: () => void;
 };
 
+export type InternalChangeEvent = {
+	value: number | null;
+};
+
+export type InternalRange = {
+	lowerBound?: number;
+	upperBound?: number;
+};
+
+export type Options = {
+	confirmText?: string;
+	cancelText?: string;
+};
+
 export type DatePickerProps = ViewProps & {
 	ref?: Ref<DatePickerHandle>;
 	type?: "date" | "time";
@@ -13,4 +27,5 @@ export type DatePickerProps = ViewProps & {
 	min?: Date;
 	max?: Date;
 	inline?: boolean;
+	options?: Options;
 };

--- a/js/RTNDatePickerNativeComponent.ts
+++ b/js/RTNDatePickerNativeComponent.ts
@@ -7,13 +7,18 @@ import type {
 	DirectEventHandler,
 } from "react-native/Libraries/Types/CodegenTypes";
 
-export interface ChangeEvent {
+interface ChangeEvent {
 	value: Double | null;
 }
 
-export interface Range {
+interface Range {
 	lowerBound?: Double;
 	upperBound?: Double;
+}
+
+interface Options {
+	confirmText?: string;
+	cancelText?: string;
 }
 
 export interface RTNDatePickerNativeProps extends ViewProps {
@@ -25,6 +30,7 @@ export interface RTNDatePickerNativeProps extends ViewProps {
 	onConfirm: DirectEventHandler<null>;
 	onCancel: DirectEventHandler<null>;
 	range: Range;
+	options: Options;
 }
 
 export default codegenNativeComponent<RTNDatePickerNativeProps>(

--- a/js/index.tsx
+++ b/js/index.tsx
@@ -1,2 +1,6 @@
 export { default as DatePicker } from "./DatePicker";
-export type { DatePickerHandle, DatePickerProps } from "./DatePicker/types";
+export type {
+	DatePickerProps,
+	DatePickerHandle,
+	Options,
+} from "./DatePicker/types";


### PR DESCRIPTION
- Fixes #1
- Fixes #13 (partially)

Checklist:
- [x] Update README.md (new prop)
- [x] Update README.md (mention that the pickerOptions should be memorized)
- [x] Android
- [x] iOS
