### PR TITLE
Update CMake target string on Android per requirement in react native 0.81

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -21,12 +21,16 @@ target_link_libraries(
   reactnative
 )
 
-target_compile_options(
-  react_codegen_RTNDatePickerSpecs
-  PRIVATE
-  -DLOG_TAG=\"ReactNative\"
-  -fexceptions
-  -frtti
-  -std=c++20
-  -Wall
-)
+if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  target_compile_reactnative_options(react_codegen_RTNDatePickerSpecs PRIVATE)
+else()
+  target_compile_options(
+    react_codegen_RTNDatePickerSpecs
+    PRIVATE
+    -DLOG_TAG=\"ReactNative\"
+    -fexceptions
+    -frtti
+    -std=c++20
+    -Wall
+  )
+endif()


### PR DESCRIPTION
This is a required change starting in react native 0.81.

From the [Changelog](https://github.com/facebook/react-native/blob/main/CHANGELOG.md#android-specific-10):
> CMake: Correctly propagate RN_SERIALIZABLE_STATE to 3rd party CMake targets. Users with custom CMake and C++ code should update to use target_compile_reactnative_options inside their CMakeLists.txt files

The reason I stumbled across it originally is because without this change, the `Pressable` component from `react-native-gesture-handler` [breaks](https://github.com/software-mansion/react-native-gesture-handler/issues/3476#issuecomment-3339953402) from RN 0.81 onward when this library is installed. It also affected the `react-native-picker` library, which had to [fix](https://github.com/react-native-picker/picker/pull/648) the same issue.

I did confirm that this change addresses the original issue I had with Pressables from RNGH.